### PR TITLE
Support client not using local certificate + bump to .NET 5

### DIFF
--- a/SwishApi/SwishApi.csproj
+++ b/SwishApi/SwishApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/RickardPettersson/swish-api-csharp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/RickardPettersson/swish-api-csharp</RepositoryUrl>

--- a/SwishApiConsoleTest/Program.cs
+++ b/SwishApiConsoleTest/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 
@@ -183,7 +183,7 @@ namespace SwishApiConsoleTest
 
             // Create a Swishpi Client object with all data needed to run a test Swish payment
             SwishApi.Client client = new SwishApi.Client(certificatePath, "swish", "https://tabetaltmedswish.se/Test/Callback/");
-            //client._enableHTTPLog = true;
+            // client.EnableHTTPLog = true;
 
             var response = client.MakePayoutRequest(Guid.NewGuid().ToString("N").ToUpper(), "1234679304", "199001019999", "1.00", "Test", "7d70445ec8ef4d1e3a713427e973d097");
 

--- a/SwishApiConsoleTest/Program.cs
+++ b/SwishApiConsoleTest/Program.cs
@@ -1,6 +1,4 @@
-using System;
-using System.Net.Http;
-using System.Security.Cryptography.X509Certificates;
+﻿using System;
 
 namespace SwishApiConsoleTest
 {
@@ -8,20 +6,21 @@ namespace SwishApiConsoleTest
     {
         static void Main(string[] args)
         {
-            //MainTestPayment(args);
-            //MainTestQCommerce(args);
-            MainTestPayout(args);
-        }
-
-        // MainTestPaymentAndRefund
-        static void MainTestPayment(string[] args)
-        {
             // Get the path for the test certificate in the TestCert folder in the console application folder, being always copy to the output folder
             string certificatePath = Environment.CurrentDirectory + "\\TestCert\\Swish_Merchant_TestCertificate_1234679304.p12";
 
             // Create a Swishpi Client object with all data needed to run a test Swish payment
             SwishApi.Client client = new SwishApi.Client(certificatePath, "swish", "https://tabetaltmedswish.se/Test/Callback/");
+            // client.EnableHTTPLog = true;
 
+            MainTestPayment(client);
+            MainTestQCommerce(client);
+            MainTestPayout(client);
+        }
+
+        // MainTestPaymentAndRefund
+        static void MainTestPayment(SwishApi.Client client)
+        {
             // Make the Payement Request
             var response = client.MakePaymentRequest("1234679304", 1, "Test");//46731596605
 
@@ -97,14 +96,8 @@ namespace SwishApiConsoleTest
         }
 
         // MainTestQCommerce
-        static void MainTestQCommerce(string[] args)
+        static void MainTestQCommerce(SwishApi.Client client)
         {
-            // Get the path for the test certificate in the TestCert folder in the console application folder, being always copy to the output folder
-            string certificatePath = Environment.CurrentDirectory + "\\TestCert\\Swish_Merchant_TestCertificate_1234679304.p12";
-
-            // Create a Swishpi Client object with all data needed to run a test Swish payment
-            SwishApi.Client client = new SwishApi.Client(certificatePath, "swish", "https://tabetaltmedswish.se/Test/Callback/");
-
             var responseMCommerce = client.MakePaymentRequestMCommerce(1, "Test");
 
             var getQRCodeResponse = client.GetQRCode(responseMCommerce.Token, "svg");
@@ -176,15 +169,8 @@ namespace SwishApiConsoleTest
             Console.ReadLine();
         }
 
-        static void MainTestPayout(string[] args)
+        static void MainTestPayout(SwishApi.Client client)
         {
-            // Get the path for the test certificate in the TestCert folder in the console application folder, being always copy to the output folder
-            string certificatePath = Environment.CurrentDirectory + "\\TestCert\\Swish_Merchant_TestCertificate_1234679304.p12";
-
-            // Create a Swishpi Client object with all data needed to run a test Swish payment
-            SwishApi.Client client = new SwishApi.Client(certificatePath, "swish", "https://tabetaltmedswish.se/Test/Callback/");
-            // client.EnableHTTPLog = true;
-
             var response = client.MakePayoutRequest(Guid.NewGuid().ToString("N").ToUpper(), "1234679304", "199001019999", "1.00", "Test", "7d70445ec8ef4d1e3a713427e973d097");
 
             if (string.IsNullOrEmpty(response.Error))

--- a/SwishApiConsoleTest/Program.cs
+++ b/SwishApiConsoleTest/Program.cs
@@ -4,14 +4,38 @@ namespace SwishApiConsoleTest
 {
     class Program
     {
+        static SwishApi.Client CreateClient(bool useLocalCertificate = true)
+        {
+            var callbackUri = "https://tabetaltmedswish.se/Test/Callback/";
+
+            SwishApi.Client client;
+
+            if (useLocalCertificate)
+            {
+                // Get the path for the test certificate in the TestCert folder in the console application folder, being always copy to the output folder
+                string certificatePath = Environment.CurrentDirectory + "\\TestCert\\Swish_Merchant_TestCertificate_1234679304.p12";
+
+                // Create a Swishpi Client object with all data needed to run a test Swish payment
+                client = new SwishApi.Client(certificatePath, "swish", callbackUri);
+            }
+            else
+            {
+                // In an architecture where we have an upstream/proxy that manage certificates,
+                // we can construct a client that don't pass a local certificate in the request.
+                //
+                // In a context like that, the URI is also not the URI to the Swish server, but
+                // but rather the URI of the proxy.
+
+                client = new SwishApi.Client(callbackUri, "https://my_certificate_proxy.corp");
+            }
+
+            // client.EnableHTTPLog = true;
+            return client;
+        }
+
         static void Main(string[] args)
         {
-            // Get the path for the test certificate in the TestCert folder in the console application folder, being always copy to the output folder
-            string certificatePath = Environment.CurrentDirectory + "\\TestCert\\Swish_Merchant_TestCertificate_1234679304.p12";
-
-            // Create a Swishpi Client object with all data needed to run a test Swish payment
-            SwishApi.Client client = new SwishApi.Client(certificatePath, "swish", "https://tabetaltmedswish.se/Test/Callback/");
-            // client.EnableHTTPLog = true;
+            var client = CreateClient();
 
             MainTestPayment(client);
             MainTestQCommerce(client);

--- a/SwishApiConsoleTest/SwishApiConsoleTest.csproj
+++ b/SwishApiConsoleTest/SwishApiConsoleTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
1. Tillåter användning av en client utan hantering av lokala certifikat.
2. Bump till .NET 5
3. Lite refactoring för (1)
  
Eventuellt något smal feature, men gör en PR om det skulle vara nåt du vill ha stöd för. Vi använder oss av en sådan arkitektur och jag använde din kod för att testa lite, så tänkte jag kunde bidra, om det var nåt du skulle vilja ha. Bara stänga PRn annars.

Test-appens default är fortfarande lokalt certifikat och ska funka precis som förut. Jag har testat lokalt och ser inte att jag skulle ha pajat nåt.

cc @RickardPettersson 